### PR TITLE
トップページの image をbootstrapのcrossfadeを使用して動きをつける

### DIFF
--- a/app/controllers/travels_controller.rb
+++ b/app/controllers/travels_controller.rb
@@ -5,18 +5,16 @@ class TravelsController < ApplicationController
   def index
     if params[:continent].present?
       # where 与えられた条件にマッチするレコードを全て返す
-      @travels = Travel.where(continent: params[:continent]).order(:id)
+      @travels = Travel.where(continent: params[:continent]).order(:id).page(params[:page]).per(3)
     elsif params[:area].present?
-      @travels = Travel.where(area: params[:area]).order(:id)
+      @travels = Travel.where(area: params[:area]).order(:id).page(params[:page]).per(3)
     else
-      @travels = Travel.order(:id)
+      @travels = Travel.order(:id).page(params[:page]).per(3)
     end
     # ユーザーがサインインしていたらお気に入り機能が使えるようになる。
     if user_signed_in?
       @favorited_travel_ids = current_user.favorites.pluck(:travel_id)
     end
-
-    @travels = Travel.page(params[:page]).per(3)
   end
 
   def new

--- a/app/views/travels/index.html.erb
+++ b/app/views/travels/index.html.erb
@@ -9,7 +9,7 @@
   <div class="text"><%= ("#{Settings.area.send(params[:area])}地方") %></div>
 </div>
 <% else %>
-<div id="carouselExampleFade" class="carousel slide carousel-fade" data-ride="carousel" data-interval="7000">
+<div id="carousel-top-fade" class="carousel slide carousel-fade" data-ride="carousel" data-interval="7000">
   <div class="carousel-inner">
     <div class="carousel-item active">
       <%= image_tag "app-top-image.jpg", class:"bd-placeholder-img w-100"%>
@@ -27,11 +27,11 @@
       <%= image_tag "tekapo.jpg", class:"bd-placeholder-img w-100"%>
     </div>
   </div>
-  <a class="carousel-control-prev" href="#carouselExampleFade" role="button" data-slide="prev">
+  <a class="carousel-control-prev" href="#carousel-top-fade" role="button" data-slide="prev">
     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
     <span class="sr-only">Previous</span>
   </a>
-  <a class="carousel-control-next" href="#carouselExampleFade" role="button" data-slide="next">
+  <a class="carousel-control-next" href="#carousel-top-fade" role="button" data-slide="next">
     <span class="carousel-control-next-icon" aria-hidden="true"></span>
     <span class="sr-only">Next</span>
   </a>


### PR DESCRIPTION
## 概要

- bootstrapのcrossfadeを導入

### 内容

- crossfadeでimgaeに動きをつけて、世界地図と日本地図のエリア別のリンクを押した時にそれぞれの画像が出てきて、ページネーションも対応。